### PR TITLE
Error Response Output

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -44,7 +44,7 @@ async function fetch(url: string, options: DataObject) {
   }
   const res = await nodefetch(url, options);
   if (!res.ok) {
-    throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
+    throw new Error(JSON.stringify(await res.json()));
   }
   logger.verbose(`[${options.method || 'GET'}: ${url}`);
   return await res.json();


### PR DESCRIPTION
This PR updates the SDK to provide the error response object (as a string) back to the app to assist with error resolution.

Existing
```
Fetch failed: 400 Bad Request
```
Proposed (example)
```
{"message":"POST failed: HTTP/1.1 400 Bad Request (url = https://idbroker-b-us.webex.com/idb/oauth2/v1/access_token, request/response TrackingId = ROUTER_64F1A18A-4D5A-01BB-00DB-0AFE4BXXXX, error = '(invalid_client) Invalid client')","errors":[{"description":"(invalid_client) Invalid client"}],"error":"invalid_client","error_description":"Invalid client","trackingId":"ROUTER_64F1A18A-4D5A-01BB-00DB-0AFE4BBXXXXX"}
```